### PR TITLE
Added ore tags for Voidic Crystal Ore

### DIFF
--- a/src/main/resources/data/forge/tags/blocks/ore_bearing_ground/bedrock.json
+++ b/src/main/resources/data/forge/tags/blocks/ore_bearing_ground/bedrock.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:bedrock"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/ores_in_ground/bedrock.json
+++ b/src/main/resources/data/forge/tags/blocks/ores_in_ground/bedrock.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "voidscape:voidic_crystal_ore"
+  ]
+}


### PR DESCRIPTION
Adds Voidic Crystal Ore to the forge tags for ores_in_ground and ore_bearing_ground. This allows mods that use these tags to interact with the ore, such as Twilight Forest's Ore Magnet. 